### PR TITLE
don't add id to auth messages

### DIFF
--- a/src/HomeAssistantWS/RemoteWS.py
+++ b/src/HomeAssistantWS/RemoteWS.py
@@ -31,7 +31,8 @@ class HomeAssistantWS(object):
         response_future = asyncio.Future(loop=self._loop)
         self._message_responses[message_id] = response_future
 
-        message['id'] = message_id
+        if message['type'] != 'auth':
+            message['id'] = message_id
         await self._websocket.send_str(json.dumps(message))
 
         return response_future


### PR DESCRIPTION
Fixes failing auth in hass 0.7x

> {'message': "Message incorrectly formatted: extra keys not allowed @ data['id']. Got 1", 'type': 'auth_invalid'}